### PR TITLE
本番への自動デプロイ時にタイムアウトになるのでタイムアウトを明示的に指定

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -8,6 +8,7 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/5

# この PR で対応する範囲 / この PR で対応しない範囲

本番デプロイ時のタイムアウトを設定する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

PRタイトルの通り。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし