### PR TITLE
LLMにエンドユーザーから送られたUserIdを渡すように変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from langchain.chat_models import ChatOpenAI
 from langchain.chains import ConversationChain
-from langchain.memory import ConversationBufferMemory
+from langchain.memory import ConversationTokenBufferMemory
 from langchain.prompts.chat import (
     ChatPromptTemplate,
     MessagesPlaceholder,
@@ -66,12 +66,12 @@ template = """
 
 user_memories = {}
 
+llm = ChatOpenAI(
+    temperature=0.7, openai_api_key=OPENAI_API_KEY, model_name="gpt-3.5-turbo"
+)
 
-def create_conversational_chain(user_memory: ConversationBufferMemory):
-    llm = ChatOpenAI(
-        temperature=0.7, openai_api_key=OPENAI_API_KEY, model_name="gpt-3.5-turbo"
-    )
 
+def create_conversational_chain(user_memory: ConversationTokenBufferMemory):
     memory = user_memory
 
     prompt = ChatPromptTemplate.from_messages(
@@ -121,7 +121,12 @@ async def cats_messages(
     try:
         user_memory = user_memories.get(
             request_body.userId,
-            ConversationBufferMemory(memory_key="history", return_messages=True),
+            ConversationTokenBufferMemory(
+                memory_key="history",
+                return_messages=True,
+                llm=llm,
+                max_token_limit=3500,
+            ),
         )
         user_memories[request_body.userId] = user_memory
 

--- a/main.py
+++ b/main.py
@@ -72,7 +72,9 @@ llm = ChatOpenAI(
 )
 
 
-def create_conversational_chain(user_memory: ConversationTokenBufferMemory):
+def create_conversational_chain(
+    user_memory: ConversationTokenBufferMemory,
+) -> ConversationChain:
     memory = user_memory
 
     prompt = ChatPromptTemplate.from_messages(
@@ -103,7 +105,7 @@ class FetchCatMessagesRequestBody(BaseModel):
 @app.post("/cats/{cat_id}/messages")
 async def cats_messages(
     request: Request, cat_id: str, request_body: FetchCatMessagesRequestBody
-):
+) -> JSONResponse:
     # TODO cat_id 毎にねこの人格を設定する
     logger.info(cat_id)
     logger.info(request_body.userId)

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 import uvicorn
+from logging import LogRecord
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -18,7 +19,7 @@ from langchain.callbacks import get_openai_callback
 
 
 class JsonFormatter(logging.Formatter):
-    def format(self, record):
+    def format(self, record: LogRecord) -> str:
         data = record.__dict__.copy()
         data["msg"] = record.getMessage()
         data["args"] = None

--- a/main.py
+++ b/main.py
@@ -102,8 +102,6 @@ async def cats_messages(
 
     authorization = request.headers.get("Authorization", None)
 
-    print(authorization)
-
     un_authorization_response_body = {
         "type": "UNAUTHORIZED",
         "title": "invalid Authorization Header.",

--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ template = """
 user_memories = {}
 
 
-def create_conversational_chain(user_memory):
+def create_conversational_chain(user_memory: ConversationBufferMemory):
     llm = ChatOpenAI(
         temperature=0.7, openai_api_key=OPENAI_API_KEY, model_name="gpt-3.5-turbo"
     )


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/13

# この PR で対応する範囲 / この PR で対応しない範囲

このPRで https://github.com/nekochans/ai-cat-api/issues/13 のDoneの定義を満たす実装が完了する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

LLMにエンドユーザーから送られたUserIdを元に作成した会話履歴を渡すように変更。

これでユーザー毎に会話履歴を保有する事が可能になった。

なるべく多くの会話履歴を覚えておく為に `ConversationTokenBufferMemory` の `max_token_limit` を 3500 まで上げた。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

インラインコメントに記載