### PR TITLE
バリデーション処理を実装

### DIFF
--- a/src/domain/message.py
+++ b/src/domain/message.py
@@ -1,0 +1,2 @@
+def is_message(value: str) -> bool:
+    return 2 <= len(value) <= 5000

--- a/src/domain/unique_id.py
+++ b/src/domain/unique_id.py
@@ -1,0 +1,18 @@
+import uuid
+import re
+
+
+def is_uuid_v4_format(uuid_str: str) -> bool:
+    try:
+        uuid_object = uuid.UUID(uuid_str, version=4)
+    except ValueError:
+        return False
+
+    return (
+        uuid_object.version == 4
+        and re.match(
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+            uuid_str,
+        )
+        is not None
+    )

--- a/src/domain/unique_id.py
+++ b/src/domain/unique_id.py
@@ -1,18 +1,8 @@
-import uuid
 import re
 
 
-def is_uuid_v4_format(uuid_str: str) -> bool:
-    try:
-        uuid_object = uuid.UUID(uuid_str, version=4)
-    except ValueError:
-        return False
-
-    return (
-        uuid_object.version == 4
-        and re.match(
-            r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
-            uuid_str,
-        )
-        is not None
+def is_uuid_format(value: str) -> bool:
+    uuid_pattern = re.compile(
+        r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     )
+    return bool(uuid_pattern.match(value))

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, field_validator
 from openai import ChatCompletion
 import tiktoken
 from infrastructure.logger import AppLogger, SuccessLogExtra, ErrorLogExtra
-from domain.unique_id import is_uuid_v4_format
+from domain.unique_id import is_uuid_format
 
 app = FastAPI(
     title="AI Cat API",
@@ -59,9 +59,9 @@ class FetchCatMessagesRequestBody(BaseModel):
     @field_validator("userId")
     @classmethod
     def user_id(cls, v: str) -> str:
-        if not is_uuid_v4_format(v):
-            raise ValueError(f"'{v}' is not UUIDv4 Format")
-        return v.title()
+        if not is_uuid_format(v):
+            raise ValueError(f"'{v}' is not in UUID format")
+        return v
 
 
 def format_sse(response_body: dict) -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -94,13 +94,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
     errors = exc.errors()
 
-    detail = ""
-
     for error in errors:
-        user_input = "null" if error["input"] is None else error["input"]
-
-        detail = f"Your request parameter is {user_input}"
-
         invalid_params.append({"name": error["loc"][1], "reason": error["msg"]})
 
     return JSONResponse(
@@ -109,7 +103,6 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
             {
                 "type": "UNPROCESSABLE_ENTITY",
                 "title": "validation Error.",
-                "detail": detail,
                 "invalidParams": invalid_params,
             }
         ),

--- a/src/main.py
+++ b/src/main.py
@@ -57,9 +57,9 @@ class FetchCatMessagesRequestBody(BaseModel):
     message: str
     conversationId: Optional[str] = None
 
-    @field_validator("userId")
+    @field_validator("userId", "conversationId")
     @classmethod
-    def validate_user_id(cls, v: str) -> str:
+    def validate_uuid(cls, v: str) -> str:
         if not is_uuid_format(v):
             raise ValueError(f"'{v}' is not in UUID format")
         return v

--- a/src/main.py
+++ b/src/main.py
@@ -7,10 +7,11 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse, JSONResponse
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from openai import ChatCompletion
 import tiktoken
 from infrastructure.logger import AppLogger, SuccessLogExtra, ErrorLogExtra
+from domain.unique_id import is_uuid_v4_format
 
 app = FastAPI(
     title="AI Cat API",
@@ -54,6 +55,13 @@ class FetchCatMessagesRequestBody(BaseModel):
     userId: str
     message: str
     conversationId: Optional[str] = None
+
+    @field_validator("userId")
+    @classmethod
+    def user_id(cls, v: str) -> str:
+        if not is_uuid_v4_format(v):
+            raise ValueError(f"'{v}' is not UUIDv4 Format")
+        return v.title()
 
 
 def format_sse(response_body: dict) -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from openai import ChatCompletion
 import tiktoken
 from infrastructure.logger import AppLogger, SuccessLogExtra, ErrorLogExtra
 from domain.unique_id import is_uuid_format
+from domain.message import is_message
 
 app = FastAPI(
     title="AI Cat API",
@@ -58,9 +59,18 @@ class FetchCatMessagesRequestBody(BaseModel):
 
     @field_validator("userId")
     @classmethod
-    def user_id(cls, v: str) -> str:
+    def validate_user_id(cls, v: str) -> str:
         if not is_uuid_format(v):
             raise ValueError(f"'{v}' is not in UUID format")
+        return v
+
+    @field_validator("message")
+    @classmethod
+    def validate_message(cls, v: str) -> str:
+        if not is_message(v):
+            raise ValueError(
+                "message must be at least 2 character and no more than 5,000 characters"
+            )
         return v
 
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/35

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/35 のDoneの定義を満たす実装は全てこのPRで行います。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

リクエストBodyに対するバリデーションを実装。

バリデーションを通過しない値が存在する場合は `RFC7807` ライクなレスポンスフォーマットを返すように変更。

## レスポンス

```
< HTTP/1.1 422 Unprocessable Entity
< date: Sun, 27 Aug 2023 14:31:27 GMT
< server: uvicorn
< content-length: 384
< content-type: application/json
<
{ [384 bytes data]
100   496  100   384  100   112  38937  11356 --:--:-- --:--:-- --:--:-- 70857
* Connection #0 to host 0.0.0.0 left intact
{
  "type": "UNPROCESSABLE_ENTITY",
  "title": "validation Error.",
  "invalidParams": [
    {
      "name": "userId",
      "reason": "Value error, 'user_12345678' is not in UUID format"
    },
    {
      "name": "message",
      "reason": "Value error, message must be at least 2 character and no more than 5,000 characters"
    },
    {
      "name": "conversationId",
      "reason": "Value error, '88bdab85-fa77-4676-9e14-c2dcf71900f2--' is not in UUID format"
    }
  ]
}
```

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし