### PR TITLE
会話履歴をRDBに保存するように改修

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -178,6 +178,36 @@ async def cats_streaming_messages(
             headers=response_headers,
         )
 
+    try:
+        connection = await create_db_connection()
+    except Exception as e:
+        extra = ErrorLogExtra(
+            request_id=response_headers.get("Ai-Meow-Cat-Request-Id"),
+            conversation_id=conversation_id,
+            cat_id=cat_id,
+            user_id=request_body.userId,
+            user_message=request_body.message,
+        )
+
+        logger.error(
+            f"An error occurred while connecting to the database: {str(e)}",
+            exc_info=True,
+            extra=extra.model_dump(),
+        )
+
+        error_response_body = {
+            "type": "INTERNAL_SERVER_ERROR",
+            "title": "an unexpected error has occurred.",
+            "detail": str(e),
+        }
+
+        return StreamingResponse(
+            content=generate_error_response(error_response_body),
+            media_type="text/event-stream",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            headers=response_headers,
+        )
+
     # ユーザーの会話履歴を取得。もしまだ存在しなければ、新しいリストを作成
     conversation_history = user_conversations.get(conversation_id, [])
 
@@ -260,6 +290,26 @@ async def cats_streaming_messages(
             # 会話履歴を更新
             user_conversations[conversation_id] = conversation_history
 
+            await connection.begin()
+
+            async with connection.cursor() as cursor:
+                sql = """
+                INSERT INTO guest_users_conversation_histories
+                (conversation_id, cat_id, user_id, user_message, ai_message)
+                VALUES (%s, %s, %s, %s, %s)
+                """
+                await cursor.execute(
+                    sql,
+                    (
+                        conversation_id,
+                        cat_id,
+                        request_body.userId,
+                        request_body.message,
+                        ai_response_message,
+                    ),
+                )
+            await connection.commit()
+
             extra = SuccessLogExtra(
                 request_id=response_headers.get("Ai-Meow-Cat-Request-Id"),
                 conversation_id=conversation_id,
@@ -275,6 +325,8 @@ async def cats_streaming_messages(
                 extra=extra.model_dump(),
             )
         except Exception as e:
+            await connection.rollback()
+
             extra = ErrorLogExtra(
                 request_id=response_headers.get("Ai-Meow-Cat-Request-Id"),
                 conversation_id=conversation_id,
@@ -296,6 +348,8 @@ async def cats_streaming_messages(
             }
 
             yield format_sse(error_response_body)
+        finally:
+            connection.close()
 
     return StreamingResponse(
         event_stream(), media_type="text/event-stream", headers=response_headers

--- a/src/main.py
+++ b/src/main.py
@@ -210,10 +210,12 @@ async def cats_streaming_messages(
             SELECT user_message, ai_message
             FROM guest_users_conversation_histories
             WHERE conversation_id = %s
-            ORDER BY created_at ASC
+            ORDER BY created_at DESC
+            LIMIT 10
             """
             await cursor.execute(sql, (conversation_id,))
             result = await cursor.fetchall()
+            result.reverse()
             conversation_history = [
                 {"role": role_type, "content": row[message_type]}
                 for row in result

--- a/src/main.py
+++ b/src/main.py
@@ -85,10 +85,6 @@ def generate_error_response(response_body: dict):
     yield format_sse(response_body)
 
 
-# ユーザーごとの会話履歴を保存する
-user_conversations = {}
-
-
 def calculate_token_count(text: str) -> int:
     tiktoken_encoding = tiktoken.encoding_for_model("gpt-3.5-turbo")
     encoded = tiktoken_encoding.encode(text)
@@ -324,12 +320,7 @@ async def cats_streaming_messages(
 
             ai_responses.append({"role": "assistant", "content": ai_response_message})
 
-            # ストリーミングが終了したときに、AIの応答を会話履歴に追加
-            conversation_history.extend(ai_responses)
-
-            # 会話履歴を更新
-            user_conversations[conversation_id] = conversation_history
-
+            # ストリーミングが終了したときに会話履歴をDBに保存する
             await connection.begin()
 
             async with connection.cursor() as cursor:

--- a/src/main.py
+++ b/src/main.py
@@ -208,8 +208,51 @@ async def cats_streaming_messages(
             headers=response_headers,
         )
 
-    # ユーザーの会話履歴を取得。もしまだ存在しなければ、新しいリストを作成
-    conversation_history = user_conversations.get(conversation_id, [])
+    try:
+        async with connection.cursor() as cursor:
+            sql = """
+            SELECT user_message, ai_message
+            FROM guest_users_conversation_histories
+            WHERE conversation_id = %s
+            ORDER BY created_at ASC
+            """
+            await cursor.execute(sql, (conversation_id,))
+            result = await cursor.fetchall()
+            conversation_history = [
+                {"role": role_type, "content": row[message_type]}
+                for row in result
+                for role_type, message_type in [
+                    ("user", "user_message"),
+                    ("assistant", "ai_message"),
+                ]
+            ]
+    except Exception as e:
+        extra = ErrorLogExtra(
+            request_id=response_headers.get("Ai-Meow-Cat-Request-Id"),
+            conversation_id=conversation_id,
+            cat_id=cat_id,
+            user_id=request_body.userId,
+            user_message=request_body.message,
+        )
+
+        logger.error(
+            f"An error occurred while executing SQL: {str(e)}",
+            exc_info=True,
+            extra=extra.model_dump(),
+        )
+
+        error_response_body = {
+            "type": "INTERNAL_SERVER_ERROR",
+            "title": "an unexpected error has occurred.",
+            "detail": str(e),
+        }
+
+        return StreamingResponse(
+            content=generate_error_response(error_response_body),
+            media_type="text/event-stream",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            headers=response_headers,
+        )
 
     # もし会話履歴がまだ存在しなければ、システムメッセージを追加
     if not conversation_history:
@@ -217,9 +260,6 @@ async def cats_streaming_messages(
 
     # 新しいメッセージを会話履歴に追加
     conversation_history.append({"role": "user", "content": request_body.message})
-
-    # 会話履歴を更新
-    user_conversations[conversation_id] = conversation_history
 
     # 実際に会話履歴に含めるメッセージ
     messages_for_chat_completion = []


### PR DESCRIPTION
# issueURL

resolve https://github.com/nekochans/ai-cat-api/issues/37

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/37 のDoneの定義を満たす実装は全てこのPRで対応します。

# Storybook の URL、 スクリーンショット

## 以下のように会話履歴がRDBに保存されている事を確認済

<img width="1331" alt="スクリーンショット 2023-09-01 23 19 07" src="https://github.com/nekochans/ai-cat-api/assets/11032365/6259793d-d9f8-4d74-999c-d044e753560f">

# 変更点概要

会話履歴をRDBに保存するように改修を実施、会話履歴を取得する処理に関してもRDBを参照するようにした。

コードベースがかなりごちゃごちゃしてしまったので、別途リファクタリングを実施する。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

インラインコメントに記載。