### PR TITLE
会話履歴がRDBに存在しない場合にエラーになってしまう現象を修正

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -215,7 +215,9 @@ async def cats_streaming_messages(
             """
             await cursor.execute(sql, (conversation_id,))
             result = await cursor.fetchall()
-            result.reverse()
+            if result:
+                result.reverse()
+
             conversation_history = [
                 {"role": role_type, "content": row[message_type]}
                 for row in result


### PR DESCRIPTION
# issueURL

なし

# この PR で対応する範囲 / この PR で対応しない範囲

新規ユーザーが正常に機能を利用出来るように修正を実施する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

タイトルの内容を修正。

会話履歴がRDBに存在しない場合に空のタプルに対して `reverse()` を実行してしまっていたので修正を実施した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

機能が壊れてしまっているので急いでデプロイする。