### PR TITLE
LLMから応答を取得する部分をリポジトリパターンを使った形に変更

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -610,6 +610,51 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.5.1"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70"},
+    {file = "mypy-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0"},
+    {file = "mypy-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12"},
+    {file = "mypy-1.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d"},
+    {file = "mypy-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25"},
+    {file = "mypy-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4"},
+    {file = "mypy-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4"},
+    {file = "mypy-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243"},
+    {file = "mypy-1.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275"},
+    {file = "mypy-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315"},
+    {file = "mypy-1.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb"},
+    {file = "mypy-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373"},
+    {file = "mypy-1.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161"},
+    {file = "mypy-1.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a"},
+    {file = "mypy-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1"},
+    {file = "mypy-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65"},
+    {file = "mypy-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160"},
+    {file = "mypy-1.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2"},
+    {file = "mypy-1.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb"},
+    {file = "mypy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"},
+    {file = "mypy-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a"},
+    {file = "mypy-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14"},
+    {file = "mypy-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb"},
+    {file = "mypy-1.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693"},
+    {file = "mypy-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770"},
+    {file = "mypy-1.5.1-py3-none-any.whl", hash = "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5"},
+    {file = "mypy-1.5.1.tar.gz", hash = "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1248,4 +1293,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "97ebf194a9f3ebca13fe0677d150e98bc90f4b4b65639cc1459ba9ebaaab5040"
+content-hash = "0116bb161220103c03a2d2c659edd619cd9f3f1069548160b6fce26c7c3ab867"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ asyncio = "^3.4.3"
 aiomysql = "^0.2.0"
 pytest = "^7.4.1"
 pytest-asyncio = "^0.21.1"
+mypy = "^1.5.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/domain/repository/cat_message_repository_interface.py
+++ b/src/domain/repository/cat_message_repository_interface.py
@@ -1,0 +1,19 @@
+from typing import Protocol, List, TypedDict, AsyncGenerator
+from domain.message import ChatMessage
+
+
+class CreateMessageForGuestUserDto(TypedDict):
+    user_id: str
+    chat_messages: List[ChatMessage]
+
+
+class CatResponseMessage(TypedDict):
+    ai_response_id: str
+    message: str
+
+
+class CatMessageRepositoryInterface(Protocol):
+    async def create_message_for_guest_user(
+        self, dto: CreateMessageForGuestUserDto
+    ) -> AsyncGenerator[CatResponseMessage, None]:
+        ...

--- a/src/infrastructure/repository/cat_message_repository.py
+++ b/src/infrastructure/repository/cat_message_repository.py
@@ -1,0 +1,52 @@
+import os
+from typing import List, TypedDict, AsyncGenerator
+from openai import ChatCompletion
+from domain.message import ChatMessage
+
+
+class CreateMessageForGuestUserDto(TypedDict):
+    user_id: str
+    chat_messages: List[ChatMessage]
+
+
+class CatResponseMessage(TypedDict):
+    ai_response_id: str
+    message: str
+
+
+class CatMessageRepository:
+    def __init__(self):
+        self.OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+
+    async def create_message_for_guest_user(
+        self, dto: CreateMessageForGuestUserDto
+    ) -> AsyncGenerator[CatResponseMessage, None]:
+        response = await ChatCompletion.acreate(
+            model="gpt-3.5-turbo-0613",
+            messages=dto.get("chat_messages"),
+            stream=True,
+            api_key=self.OPENAI_API_KEY,
+            temperature=0.7,
+            user=dto.get("user_id"),
+        )
+
+        ai_response_id = ""
+        async for chunk in response:
+            chunk_message = (
+                chunk.get("choices")[0]["delta"].get("content")
+                if chunk.get("choices")[0]["delta"].get("content")
+                else ""
+            )
+
+            if ai_response_id == "":
+                ai_response_id = chunk.get("id")
+
+            if chunk_message == "":
+                continue
+
+            chunk_body = {
+                "ai_response_id": ai_response_id,
+                "message": chunk_message,
+            }
+
+            yield chunk_body

--- a/src/infrastructure/repository/cat_message_repository.py
+++ b/src/infrastructure/repository/cat_message_repository.py
@@ -1,20 +1,14 @@
 import os
-from typing import List, TypedDict, AsyncGenerator
+from typing import AsyncGenerator
 from openai import ChatCompletion
-from domain.message import ChatMessage
+from domain.repository.cat_message_repository_interface import (
+    CatMessageRepositoryInterface,
+    CreateMessageForGuestUserDto,
+    CatResponseMessage,
+)
 
 
-class CreateMessageForGuestUserDto(TypedDict):
-    user_id: str
-    chat_messages: List[ChatMessage]
-
-
-class CatResponseMessage(TypedDict):
-    ai_response_id: str
-    message: str
-
-
-class CatMessageRepository:
+class CatMessageRepository(CatMessageRepositoryInterface):
     def __init__(self):
         self.OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
 

--- a/src/infrastructure/repository/cat_message_repository.py
+++ b/src/infrastructure/repository/cat_message_repository.py
@@ -2,13 +2,12 @@ import os
 from typing import AsyncGenerator
 from openai import ChatCompletion
 from domain.repository.cat_message_repository_interface import (
-    CatMessageRepositoryInterface,
     CreateMessageForGuestUserDto,
     CatResponseMessage,
 )
 
 
-class CatMessageRepository(CatMessageRepositoryInterface):
+class CatMessageRepository:
     def __init__(self):
         self.OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
 

--- a/src/infrastructure/repository/cat_message_repository.py
+++ b/src/infrastructure/repository/cat_message_repository.py
@@ -8,7 +8,7 @@ from domain.repository.cat_message_repository_interface import (
 
 
 class CatMessageRepository:
-    def __init__(self):
+    def __init__(self) -> None:
         self.OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
 
     async def create_message_for_guest_user(
@@ -21,7 +21,7 @@ class CatMessageRepository:
             api_key=self.OPENAI_API_KEY,
             temperature=0.7,
             user=dto.get("user_id"),
-        )
+        )  # type: ignore
 
         ai_response_id = ""
         async for chunk in response:
@@ -37,7 +37,7 @@ class CatMessageRepository:
             if chunk_message == "":
                 continue
 
-            chunk_body = {
+            chunk_body: CatResponseMessage = {
                 "ai_response_id": ai_response_id,
                 "message": chunk_message,
             }


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/50

# この PR で対応する範囲 / この PR で対応しない範囲

LLMからの応答を取得する部分をRepositoryクラスに移行する。

他の部分に関してはこのPRでは対応しない。

# 変更点概要

`CatMessageRepository` を作成してLLMから応答を取得する部分を移行した。

インターフェースは `domain` packageに作成した。

Pythonはインターフェース構文をサポートしていないので代わりに `Protocol` を使った。

`ABC` を使った実装もあるがインターフェースという用途であれば `Protocol` のほうが適していると判断した。

https://zenn.dev/ibaraki/articles/bef0b43522475b

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし