### PR TITLE
mypy をCIで実行するように改修

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ format:
 	black .
 
 typecheck:
-	mypy --strict
+	poetry run python -m mypy --strict
 
 test:
 	poetry run python -m pytest -v

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,13 @@ lint:
 format:
 	black .
 
+typecheck:
+	mypy --strict
+
 test:
 	poetry run python -m pytest -v
 
-ci: test
+ci: test typecheck
 	poetry run flake8 .
 	poetry run black --check .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,8 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
+
+[tool.mypy]
+files = "src/"
+python_version = "3.11"
+ignore_missing_imports = true

--- a/src/infrastructure/logger.py
+++ b/src/infrastructure/logger.py
@@ -36,7 +36,7 @@ LogLevel = Literal[0, 10, 20, 30, 40, 50]
 
 
 class AppLogger:
-    def __init__(self, level: LogLevel = INFO) -> None:
+    def __init__(self, level: LogLevel = INFO) -> None:  # type: ignore
         self._logger = getLogger()
         self._logger.setLevel(level)
 

--- a/src/infrastructure/repository/guest_users_conversation_history_repository.py
+++ b/src/infrastructure/repository/guest_users_conversation_history_repository.py
@@ -1,5 +1,5 @@
 from typing import cast, List, Literal
-import aiomysql  # type: ignore
+import aiomysql
 from domain.cat import get_prompt_by_cat_id
 from domain.message import ChatMessage
 from domain.repository.guest_users_conversation_history_repository_interface import (

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse, JSONResponse
-from typing import Optional
+from typing import Optional, Dict, Any
 from pydantic import BaseModel, field_validator
 from infrastructure.logger import AppLogger, SuccessLogExtra, ErrorLogExtra
 from infrastructure.db import create_db_connection
@@ -51,13 +51,13 @@ class FetchCatMessagesRequestBody(BaseModel):
         return v
 
 
-def format_sse(response_body: dict) -> str:
+def format_sse(response_body: Dict[str, Any]) -> str:
     json_body = json.dumps(response_body, ensure_ascii=False)
     sse_message = f"data: {json_body}\n\n"
     return sse_message
 
 
-def generate_error_response(response_body: dict):
+def generate_error_response(response_body: Dict[str, Any]):
     yield format_sse(response_body)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -177,14 +177,14 @@ async def cats_streaming_messages(
             ).model_dump(),
         )
 
-        error_response_body = {
+        db_error_response_body = {
             "type": "INTERNAL_SERVER_ERROR",
             "title": "an unexpected error has occurred.",
             "detail": str(e),
         }
 
         return StreamingResponse(
-            content=generate_error_response(error_response_body),
+            content=generate_error_response(db_error_response_body),
             media_type="text/event-stream",
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             headers=response_headers,
@@ -264,13 +264,13 @@ async def cats_streaming_messages(
                 ).model_dump(),
             )
 
-            error_response_body = {
+            unexpected_error_response_body = {
                 "type": "INTERNAL_SERVER_ERROR",
                 "title": "an unexpected error has occurred.",
                 "detail": str(e),
             }
 
-            yield format_sse(error_response_body)
+            yield format_sse(unexpected_error_response_body)
         finally:
             connection.close()
 

--- a/src/main.py
+++ b/src/main.py
@@ -279,7 +279,7 @@ async def cats_streaming_messages(
     )
 
 
-def start():
+def start() -> None:
     uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse, JSONResponse
-from typing import Optional, Dict, Any, Generator
+from typing import Optional, Dict, Any, Generator, AsyncGenerator
 from pydantic import BaseModel, field_validator
 from infrastructure.logger import AppLogger, SuccessLogExtra, ErrorLogExtra
 from infrastructure.db import create_db_connection
@@ -20,6 +20,7 @@ from domain.cat import CatId
 from domain.repository.cat_message_repository_interface import (
     CreateMessageForGuestUserDto,
 )
+from domain.repository.cat_message_repository_interface import CatResponseMessage
 
 app = FastAPI(
     title="AI Cat API",
@@ -187,7 +188,7 @@ async def cats_streaming_messages(
             headers=response_headers,
         )
 
-    async def event_stream() -> Generator[str, None, None]:
+    async def event_stream() -> AsyncGenerator[CatResponseMessage, None]:
         try:
             # AIの応答を一時的に保存するためのリスト
             ai_responses = []

--- a/src/main.py
+++ b/src/main.py
@@ -57,12 +57,16 @@ def format_sse(response_body: Dict[str, Any]) -> str:
     return sse_message
 
 
-def generate_error_response(response_body: Dict[str, Any]) -> Generator[str, None, None]:
+def generate_error_response(
+    response_body: Dict[str, Any]
+) -> Generator[str, None, None]:
     yield format_sse(response_body)
 
 
 @app.exception_handler(RequestValidationError)
-async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
     invalid_params = []
 
     errors = exc.errors()
@@ -180,7 +184,7 @@ async def cats_streaming_messages(
             headers=response_headers,
         )
 
-    async def event_stream():
+    async def event_stream() -> Generator[str, None, None]:
         try:
             # AIの応答を一時的に保存するためのリスト
             ai_responses = []

--- a/src/main.py
+++ b/src/main.py
@@ -154,7 +154,7 @@ async def cats_streaming_messages(
         )
     except Exception as e:
         extra = ErrorLogExtra(
-            request_id=response_headers.get("Ai-Meow-Cat-Request-Id"),
+            request_id=response_headers["Ai-Meow-Cat-Request-Id"],
             conversation_id=conversation_id,
             cat_id=cat_id,
             user_id=request_body.userId,

--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse, JSONResponse
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Generator
 from pydantic import BaseModel, field_validator
 from infrastructure.logger import AppLogger, SuccessLogExtra, ErrorLogExtra
 from infrastructure.db import create_db_connection
@@ -57,12 +57,12 @@ def format_sse(response_body: Dict[str, Any]) -> str:
     return sse_message
 
 
-def generate_error_response(response_body: Dict[str, Any]):
+def generate_error_response(response_body: Dict[str, Any]) -> Generator[str, None, None]:
     yield format_sse(response_body)
 
 
 @app.exception_handler(RequestValidationError)
-async def validation_exception_handler(request: Request, exc: RequestValidationError):
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
     invalid_params = []
 
     errors = exc.errors()

--- a/src/main.py
+++ b/src/main.py
@@ -242,7 +242,7 @@ async def cats_streaming_messages(
             await connection.commit()
 
             extra = SuccessLogExtra(
-                request_id=response_headers.get("Ai-Meow-Cat-Request-Id"),
+                request_id=response_headers["Ai-Meow-Cat-Request-Id"],
                 conversation_id=conversation_id,
                 cat_id=cat_id,
                 user_id=request_body.userId,
@@ -257,7 +257,7 @@ async def cats_streaming_messages(
             await connection.rollback()
 
             extra = ErrorLogExtra(
-                request_id=response_headers.get("Ai-Meow-Cat-Request-Id"),
+                request_id=response_headers["Ai-Meow-Cat-Request-Id"],
                 conversation_id=conversation_id,
                 cat_id=cat_id,
                 user_id=request_body.userId,

--- a/src/main.py
+++ b/src/main.py
@@ -208,10 +208,10 @@ async def cats_streaming_messages(
                 create_message_for_guest_user_dto
             ):
                 # AIの応答を更新
-                ai_response_message += chunk.get("message")
+                ai_response_message += chunk.get("message") or ""
 
                 if ai_response_id == "":
-                    ai_response_id = chunk.get("ai_response_id")
+                    ai_response_id = chunk.get("ai_response_id") or ""
 
                 chunk_body = {
                     "conversationId": conversation_id,

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,9 @@ from infrastructure.repository.cat_message_repository import CatMessageRepositor
 from domain.unique_id import is_uuid_format
 from domain.message import is_message
 from domain.cat import CatId
+from domain.repository.cat_message_repository_interface import (
+    CreateMessageForGuestUserDto,
+)
 
 app = FastAPI(
     title="AI Cat API",
@@ -194,10 +197,10 @@ async def cats_streaming_messages(
 
             cat_message_repository = CatMessageRepository()
 
-            create_message_for_guest_user_dto = {
-                "user_id": request_body.userId,
-                "chat_messages": chat_messages,
-            }
+            create_message_for_guest_user_dto = CreateMessageForGuestUserDto(
+                user_id=request_body.userId,
+                chat_messages=chat_messages,
+            )
 
             ai_response_id = ""
             async for chunk in cat_message_repository.create_message_for_guest_user(

--- a/src/main.py
+++ b/src/main.py
@@ -165,18 +165,16 @@ async def cats_streaming_messages(
             }
         )
     except Exception as e:
-        extra = ErrorLogExtra(
-            request_id=response_headers["Ai-Meow-Cat-Request-Id"],
-            conversation_id=conversation_id,
-            cat_id=cat_id,
-            user_id=request_body.userId,
-            user_message=request_body.message,
-        )
-
         logger.error(
             f"An error occurred while connecting to the database: {str(e)}",
             exc_info=True,
-            extra=extra.model_dump(),
+            extra=ErrorLogExtra(
+                request_id=response_headers["Ai-Meow-Cat-Request-Id"],
+                conversation_id=conversation_id,
+                cat_id=cat_id,
+                user_id=request_body.userId,
+                user_message=request_body.message,
+            ).model_dump(),
         )
 
         error_response_body = {
@@ -241,33 +239,29 @@ async def cats_streaming_messages(
 
             await connection.commit()
 
-            extra = SuccessLogExtra(
-                request_id=response_headers["Ai-Meow-Cat-Request-Id"],
-                conversation_id=conversation_id,
-                cat_id=cat_id,
-                user_id=request_body.userId,
-                ai_response_id=ai_response_id,
-            )
-
             logger.info(
                 "success",
-                extra=extra.model_dump(),
+                extra=SuccessLogExtra(
+                    request_id=response_headers["Ai-Meow-Cat-Request-Id"],
+                    conversation_id=conversation_id,
+                    cat_id=cat_id,
+                    user_id=request_body.userId,
+                    ai_response_id=ai_response_id,
+                ).model_dump(),
             )
         except Exception as e:
             await connection.rollback()
 
-            extra = ErrorLogExtra(
-                request_id=response_headers["Ai-Meow-Cat-Request-Id"],
-                conversation_id=conversation_id,
-                cat_id=cat_id,
-                user_id=request_body.userId,
-                user_message=request_body.message,
-            )
-
             logger.error(
                 f"An error occurred while creating the message: {str(e)}",
                 exc_info=True,
-                extra=extra.model_dump(),
+                extra=ErrorLogExtra(
+                    request_id=response_headers["Ai-Meow-Cat-Request-Id"],
+                    conversation_id=conversation_id,
+                    cat_id=cat_id,
+                    user_id=request_body.userId,
+                    user_message=request_body.message,
+                ).model_dump(),
             )
 
             error_response_body = {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/58

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/58 のDoneの定義を満たす実装は全てこのPRで対応。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

`make typecheck` で `mypy --strict` を `src/` 全体に実行出来るようにした。CIでもこれを実行する事で型エラーが存在するファイルはコミット出来なくなった。

現時点で出現した型チェックエラーは全て対応している。

`tests/` に関しては未対応としている。今後余裕があれば対応するかもしれないが優先度は低とするつもり。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし