### PR TITLE
コンテナでWebAPIサーバーを起動出来るように変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,18 @@ typecheck:
 test:
 	poetry run python -m pytest -vv
 
+lint-container:
+	docker compose exec ai-cat-api bash -c "cd / && poetry run flake8 src/ tests/"
+
+format-container:
+	docker compose exec ai-cat-api bash -c "cd / && poetry run black src/ tests/"
+
+test-container:
+	docker compose exec ai-cat-api bash -c "cd / && poetry run python -m pytest -vv"
+
+typecheck-container:
+	docker compose exec ai-cat-api bash -c "cd / && poetry run python -m mypy --strict"
+
 ci: test typecheck
 	poetry run flake8 .
 	poetry run black --check .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  ai-cat-api:
+    build: .
+    ports:
+      - "5002:5000"
+    environment:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      BASIC_AUTH_USERNAME: ${BASIC_AUTH_USERNAME}
+      BASIC_AUTH_PASSWORD: ${BASIC_AUTH_PASSWORD}
+      DB_HOST: ${DB_HOST}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+    volumes:
+      - ./.flake8:/.flake8
+      - ./Makefile:/Makefile
+      - ./pyproject.toml:/pyproject.toml
+      - ./poetry.lock:/poetry.lock
+      - ./src:/src
+      - ./tests:/tests
+    command: uvicorn main:app --reload --host 0.0.0.0 --port 5000


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/73

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/73 の完了の定義にある通りに DockerでAPIサーバーが起動出来るように対応する。

DBサーバーに関しては別のPRで対応する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

`docker compose` でAPIサーバー側の環境構築が出来るように改修。

ついでに古くなっていたREADMEの手順も最新に更新。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし