### PR TITLE
テスト用のDBコネクションを生成する関数を分離

### DIFF
--- a/src/infrastructure/db.py
+++ b/src/infrastructure/db.py
@@ -8,22 +8,8 @@ ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 ctx.load_verify_locations(cafile=os.getenv("SSL_CERT_PATH"))
 
 
-async def create_db_connection(db_name: str = "") -> Connection:
+async def create_db_connection() -> Connection:
     loop = asyncio.get_event_loop()
-
-    if os.getenv("IS_TESTING") == "1":
-        use_db_name = db_name if db_name != "ai_cat_api_test" else os.getenv("DB_NAME")
-
-        connection = await aiomysql.connect(
-            host="ai-cat-api-mysql",
-            port=3306,
-            user="root",
-            password=os.getenv("DB_PASSWORD"),
-            db=use_db_name,
-            loop=loop,
-            cursorclass=aiomysql.DictCursor,
-        )
-        return connection
 
     connection = await aiomysql.connect(
         host=os.getenv("DB_HOST"),

--- a/tests/db/create_and_setup_db_connection.py
+++ b/tests/db/create_and_setup_db_connection.py
@@ -1,0 +1,44 @@
+import os
+import asyncio
+import aiomysql
+from aiomysql import Connection
+from typing import Tuple
+from tests.db.setup_test_database import setup_test_database, create_test_db_name
+
+
+async def create_and_setup_db_connection() -> Tuple[Connection, str]:
+    loop = asyncio.get_event_loop()
+
+    host = "ai-cat-api-mysql"
+    port = 3306
+    user = "root"
+    password = os.getenv("DB_PASSWORD")
+
+    connection = await aiomysql.connect(
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        db="ai_cat_api_test",
+        loop=loop,
+        cursorclass=aiomysql.DictCursor,
+    )
+
+    test_db_name = create_test_db_name()
+
+    await setup_test_database(
+        connection,
+        test_db_name,
+    )
+
+    connection = await aiomysql.connect(
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        db=test_db_name,
+        loop=loop,
+        cursorclass=aiomysql.DictCursor,
+    )
+
+    return connection, test_db_name

--- a/tests/db/setup_test_database.py
+++ b/tests/db/setup_test_database.py
@@ -3,6 +3,7 @@ import requests
 import uuid
 from typing import TypedDict, List
 from aiomysql import Connection
+from functools import lru_cache
 
 
 class TableSchema(TypedDict):
@@ -16,6 +17,7 @@ class BranchSchemas(TypedDict):
     data: List[TableSchema]
 
 
+@lru_cache()
 def fetch_db_branch_schemas() -> BranchSchemas:
     org = os.getenv("PLANET_SCALE_ORG")
     db = os.getenv("PLANET_SCALE_TEST_DB_NAME")

--- a/tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_create_messages_with_conversation_history.py
+++ b/tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_create_messages_with_conversation_history.py
@@ -1,9 +1,8 @@
 import pytest
 from typing import Tuple
 from aiomysql import Connection
-from tests.db.setup_test_database import setup_test_database, create_test_db_name
 from domain.cat import get_prompt_by_cat_id
-from infrastructure.db import create_db_connection
+from tests.db.create_and_setup_db_connection import create_and_setup_db_connection
 from infrastructure.repository.aiomysql.aiomysql_guest_users_conversation_history_repository import (
     AiomysqlGuestUsersConversationHistoryRepository,
     CreateMessagesWithConversationHistoryDto,
@@ -12,14 +11,7 @@ from infrastructure.repository.aiomysql.aiomysql_guest_users_conversation_histor
 
 @pytest.fixture
 async def create_test_db_connection() -> Tuple[Connection, str]:
-    test_db_name = create_test_db_name()
-
-    connection = await create_db_connection()
-
-    await setup_test_database(
-        connection,
-        test_db_name,
-    )
+    connection, test_db_name = await create_and_setup_db_connection()
 
     async with connection.cursor() as cursor:
         await cursor.execute("TRUNCATE TABLE guest_users_conversation_histories")
@@ -167,5 +159,3 @@ async def test_create_messages_with_conversation_history(create_test_db_connecti
         assert (
             chat_messages[i]["content"] == expected[i]["content"]
         ), f"Content mismatch at index {i}"
-
-    create_test_db_connection.close()

--- a/tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_save_conversation_history.py
+++ b/tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_save_conversation_history.py
@@ -55,5 +55,3 @@ async def test_save_conversation_history(create_test_db_connection):
     assert result["user_id"] == user_id
     assert result["user_message"] == dto.get("user_message")
     assert result["ai_message"] == dto.get("ai_message")
-
-    create_test_db_connection.close()

--- a/tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_save_conversation_history.py
+++ b/tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_save_conversation_history.py
@@ -1,8 +1,7 @@
 import pytest
 from typing import Tuple
 from aiomysql import Connection
-from tests.db.setup_test_database import setup_test_database, create_test_db_name
-from infrastructure.db import create_db_connection
+from tests.db.create_and_setup_db_connection import create_and_setup_db_connection
 from infrastructure.repository.aiomysql.aiomysql_guest_users_conversation_history_repository import (
     AiomysqlGuestUsersConversationHistoryRepository,
     SaveGuestUsersConversationHistoryDto,
@@ -11,14 +10,7 @@ from infrastructure.repository.aiomysql.aiomysql_guest_users_conversation_histor
 
 @pytest.fixture
 async def create_test_db_connection() -> Tuple[Connection, str]:
-    test_db_name = create_test_db_name()
-
-    connection = await create_db_connection()
-
-    await setup_test_database(
-        connection,
-        test_db_name,
-    )
+    connection, test_db_name = await create_and_setup_db_connection()
 
     async with connection.cursor() as cursor:
         await cursor.execute("TRUNCATE TABLE guest_users_conversation_histories")


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/84

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/84 の完了の定義を満たす為の実装 + `setup_test_database` のリファクタリングを実施します。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

テスト用のDBコネクションを生成する関数を `create_and_setup_db_connection` として定義。

この中でテスト用のDBの作成も行うようにしたので各テストの `fixture` の実装はシンプルになった。

またPRの目的とはズレるが PlanetScaleのAPIの結果をcacheするように変更した。

これによりAPIをコールする回数も減っているハズ。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
