### PR TITLE
MySQLコンテナの設定、バージョンをPlanetScaleに合わせて変更

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,3 +1,3 @@
-FROM mysql:8.0.26
+FROM mysql:8.0.34
 
 COPY ./docker/mysql/config/my.cnf /etc/mysql/conf.d/my.cnf

--- a/docker/mysql/config/my.cnf
+++ b/docker/mysql/config/my.cnf
@@ -1,6 +1,5 @@
 [mysqld]
 character-set-server=utf8mb4
-collation-server=utf8mb4_bin
 
 # デフォルト認証プラグイン
 default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/81

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/81 の完了の定義を満たす為の実装は全てこのPR内で実装します。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

MySQLコンテナの設定、バージョンをPlanetScaleに合わせて変更。

PlanetScaleのバージョンは下記の通り。

```
> SELECT VERSION();
+---------------+
| VERSION()     |
+---------------+
| 8.0.34-Vitess |
+---------------+
```

Vitessは通常のMySQLと差異があるがそれでもバージョンを合わせておいたほうが良いと判断した。

また `SHOW VARIABLES LIKE 'collation%';` の結果も以下のようになっているのでこちらも合わせて変更した。

```
+----------------------+--------------------+
| Variable_name        | Value              |
+----------------------+--------------------+
| collation_connection | utf8mb4_0900_ai_ci |
| collation_database   | utf8mb4_0900_ai_ci |
| collation_server     | utf8mb4_0900_ai_ci |
+----------------------+--------------------+
```

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし