### PR TITLE
テストコードのアサーションをシンプルな形に変更

### DIFF
--- a/tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_create_messages_with_conversation_history.py
+++ b/tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_create_messages_with_conversation_history.py
@@ -150,12 +150,4 @@ async def test_create_messages_with_conversation_history(create_test_db_connecti
         {"role": "user", "content": "いっしょに白いごはんを食べよう！"},
     ]
 
-    assert len(chat_messages) == len(expected), "Length mismatch"
-
-    for i in range(len(chat_messages)):
-        assert (
-            chat_messages[i]["role"] == expected[i]["role"]
-        ), f"Role mismatch at index {i}"
-        assert (
-            chat_messages[i]["content"] == expected[i]["content"]
-        ), f"Content mismatch at index {i}"
+    assert expected == chat_messages


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/86

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/86 の完了の定義を満たす実装は全てこのPR内で実装します。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

タイトルの通りで、単純に `assert` で比較するだけで十分にテストの目的を達成出来るので書き方をシンプルな形に変更。

ちなみにテストが失敗した場合は以下のようになる。

```
E            {'content': 'ふふふ🐱あらためてよろしく、もこちゃん！', 'role': 'user'},
E            {'content': 'よろしくにゃ🐱コメちゃん🐱', 'role': 'assistant'},
E            {'content': 'もこちゃんの好きな食べ物は🐱？', 'role': 'user'},
E            {'content': 'もこはチキン味のカリカリだにゃ🐱それしか食べないにゃ🐱', 'role': 'assistant'},
E            {'content': 'チュールは🐱？', 'role': 'user'},
E            {'content': 'チュールは苦手だにゃ🐱', 'role': 'assistant'},
E            {'content': 'チュール嫌いなねこちゃんもいるんだね！', 'role': 'user'},
E            {'content': 'もこは苦手だにゃ🐱コメちゃんの好きな食べ物も教えてにゃ🐱', 'role': 'assistant'},
E         +  {'content': '確かに人間は白いごはんをよく食べてるにゃ🐱', 'role': 'assistant'},
E            {'content': '私はコメって名前の通り白いごはんが好きだよ！', 'role': 'user'},
E         -  {'content': '確かに人間は白いごはんをよく食べてるにゃ🐱', 'role': 'assistant'},
E            {'content': 'そうそう白いごはんは美味しいよ！', 'role': 'user'},
E            {'content': 'にゃーもこも白いごはん食べたいにゃ🐱', 'role': 'assistant'},
E            {'content': 'いっしょに白いごはんを食べよう！', 'role': 'user'},
E           ]

tests/infrastructure/repository/aiomysql/aiomysql_guest_users_conversation_history/test_create_messages_with_conversation_history.py:154: AssertionError
```

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし