### PR TITLE
ジェネレータメソッドであるCatMessageRepository.generate_message_for_guest_user の型定義を適切な形に変更

### DIFF
--- a/src/domain/repository/cat_message_repository_interface.py
+++ b/src/domain/repository/cat_message_repository_interface.py
@@ -1,4 +1,5 @@
-from typing import Protocol, List, TypedDict, AsyncGenerator
+from typing import Protocol, List, TypedDict
+from collections.abc import AsyncIterator
 from domain.message import ChatMessage
 
 
@@ -13,6 +14,6 @@ class GenerateMessageForGuestUserResult(TypedDict):
 
 
 class CatMessageRepositoryInterface(Protocol):
-    async def generate_message_for_guest_user(
+    def generate_message_for_guest_user(
         self, dto: GenerateMessageForGuestUserDto
-    ) -> AsyncGenerator[GenerateMessageForGuestUserResult, None]: ...
+    ) -> AsyncIterator[GenerateMessageForGuestUserResult]: ...

--- a/src/infrastructure/repository/mock/mock_cat_message_repository.py
+++ b/src/infrastructure/repository/mock/mock_cat_message_repository.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import AsyncGenerator
+from collections.abc import AsyncIterator
 from domain.repository.cat_message_repository_interface import (
     CatMessageRepositoryInterface,
     GenerateMessageForGuestUserDto,
@@ -8,9 +8,9 @@ from domain.repository.cat_message_repository_interface import (
 
 
 class MockCatMessageRepository(CatMessageRepositoryInterface):
-    async def generate_message_for_guest_user(  # type: ignore
+    async def generate_message_for_guest_user(
         self, dto: GenerateMessageForGuestUserDto
-    ) -> AsyncGenerator[GenerateMessageForGuestUserResult, None]:
+    ) -> AsyncIterator[GenerateMessageForGuestUserResult]:
         messages = [
             "はじめましてだにゃん",
             "🐱",

--- a/src/infrastructure/repository/openai/openai_cat_message_repository.py
+++ b/src/infrastructure/repository/openai/openai_cat_message_repository.py
@@ -4,7 +4,8 @@ import httpx
 import json
 from datetime import datetime
 from zoneinfo import ZoneInfo
-from typing import AsyncGenerator, cast, List, TypedDict, Union
+from typing import cast, List, TypedDict, Union
+from collections.abc import AsyncIterator
 from openai import AsyncOpenAI, AsyncStream
 from openai.types.chat import (
     ChatCompletionMessageParam,
@@ -35,11 +36,9 @@ class OpenAiCatMessageRepository(CatMessageRepositoryInterface):
         self.OPEN_WEATHER_API_KEY = os.environ["OPEN_WEATHER_API_KEY"]
         self.client = AsyncOpenAI(api_key=self.OPENAI_API_KEY)
 
-    # TODO: 型は合っているのに型チェックエラーが出る mypy が AsyncGenerator に対応していない可能性がある
-    # TODO: https://github.com/nekochans/ai-cat-api/issues/68 で別の型チェックツールを試してみる
-    async def generate_message_for_guest_user(  # type: ignore
+    async def generate_message_for_guest_user(
         self, dto: GenerateMessageForGuestUserDto
-    ) -> AsyncGenerator[GenerateMessageForGuestUserResult, None]:
+    ) -> AsyncIterator[GenerateMessageForGuestUserResult]:
         messages = cast(List[ChatCompletionMessageParam], dto.get("chat_messages"))
         user = str(dto.get("user_id"))
 
@@ -228,7 +227,7 @@ class OpenAiCatMessageRepository(CatMessageRepositoryInterface):
     @staticmethod
     async def _extract_chat_chunks(
         async_stream: AsyncStream[ChatCompletionChunk],
-    ) -> AsyncGenerator[GenerateMessageForGuestUserResult, None]:
+    ) -> AsyncIterator[GenerateMessageForGuestUserResult]:
         ai_response_id = ""
         async for chunk in async_stream:
             chunk_message: str = (

--- a/src/usecase/generate_cat_message_for_guest_user_use_case.py
+++ b/src/usecase/generate_cat_message_for_guest_user_use_case.py
@@ -132,7 +132,7 @@ class GenerateCatMessageForGuestUserUseCase:
 
             ai_response_id = ""
 
-            async for chunk in self.dto["cat_message_repository"].generate_message_for_guest_user(  # type: ignore
+            async for chunk in self.dto["cat_message_repository"].generate_message_for_guest_user(
                 create_message_for_guest_user_dto
             ):
                 # AIの応答を更新

--- a/src/usecase/generate_cat_message_for_guest_user_use_case.py
+++ b/src/usecase/generate_cat_message_for_guest_user_use_case.py
@@ -132,9 +132,9 @@ class GenerateCatMessageForGuestUserUseCase:
 
             ai_response_id = ""
 
-            async for chunk in self.dto["cat_message_repository"].generate_message_for_guest_user(
-                create_message_for_guest_user_dto
-            ):
+            async for chunk in self.dto[
+                "cat_message_repository"
+            ].generate_message_for_guest_user(create_message_for_guest_user_dto):
                 # AIの応答を更新
                 ai_response_message += chunk.get("message") or ""
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/96

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/96 の完了の定義に記載されている通り、`CatMessageRepository.generate_message_for_guest_user` の型定義を現時点でベストと思われる形に変更する。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし

# 変更点概要

タイトルの通りジェネレータメソッドである `CatMessageRepository.generate_message_for_guest_user` の型定義を現時点でベストと思われる内容に変更。

実装当時は正直Pythonにも不慣れでジェネレータの型定義方法をあまり良く分かっておらず `# type: ignore` を使って `mypy` のチェックを回避していたが以下の記事を見て `from collections.abc import AsyncIterator` を利用する形に変更した。（元記事では非同期関数ではないので `Iterator` を利用）

https://nikkie-ftnext.hatenablog.com/entry/generator-function-return-value-type-hint

この変更により `mypy` のチェックを無事に通過するようになり `# type: ignore` を削除する事になった。

ちなみに元記事では `from collections.abc import Generator` を利用していたが、`None` を利用しないといけないのでよりシンプルな型定義で済む `Iterator`（`AsyncIterator`） を使ったほうがシンプルになると判断した。

# レビュアーに重点的にチェックして欲しい点

おそらく今の形がベストではと思っているが、もしも更により型定義の方法があれば教えていただけると🙏

# 補足情報

インラインコメント記載。
