### PR TITLE
ユースケース、コントローラーのレスポンス型定義を collections.abc.AsyncIterator に変更

### DIFF
--- a/src/presentation/controller/generate_cat_message_for_guest_user_controller.py
+++ b/src/presentation/controller/generate_cat_message_for_guest_user_controller.py
@@ -1,4 +1,5 @@
-from typing import Optional, AsyncGenerator, cast
+from typing import Optional, cast
+from collections.abc import AsyncIterator
 from fastapi import status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, field_validator
@@ -128,9 +129,7 @@ class GenerateCatMessageForGuestUserController:
 
         use_case = GenerateCatMessageForGuestUserUseCase(use_case_dto)
 
-        async def generate_cat_message_for_guest_user_stream() -> (
-            AsyncGenerator[str, None]
-        ):
+        async def generate_cat_message_for_guest_user_stream() -> AsyncIterator[str]:
             async for chunk in use_case.execute():
                 use_case_result: GenerateCatMessageForGuestUserUseCaseResult = chunk
 

--- a/src/usecase/generate_cat_message_for_guest_user_use_case.py
+++ b/src/usecase/generate_cat_message_for_guest_user_use_case.py
@@ -1,4 +1,5 @@
-from typing import TypedDict, AsyncGenerator, Union, Dict, Any
+from typing import TypedDict, Union, Dict, Any
+from collections.abc import AsyncIterator
 from usecase.db_handler_interface import DbHandlerInterface
 from domain.repository.guest_users_conversation_history_repository_interface import (
     GuestUsersConversationHistoryRepositoryInterface,
@@ -82,7 +83,7 @@ class GenerateCatMessageForGuestUserUseCase:
 
     async def execute(
         self,
-    ) -> AsyncGenerator[GenerateCatMessageForGuestUserUseCaseResult, None]:
+    ) -> AsyncIterator[GenerateCatMessageForGuestUserUseCaseResult]:
         conversation_id: str = self.dto["request_id"]
         if self.dto.get("conversation_id") is not None:
             conversation_id = self.dto["conversation_id"]


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/99

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/99 の完了の定義に記載されている通りユースケースのレスポンス型定義を `collections.abc.AsyncIterator` に変更する。

# Storybook の URL、 スクリーンショット

UI変更ではないのでなし

# 変更点概要

タイトルの通り。

元々ユースケースだけを対応する予定だったがコントローラー内の `StreamingResponse` を生成している関数内でもジェネレータメソッドが利用されていたのでコントローラーでも `AsyncIterator` を利用するようにした。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
