### PR TITLE
Fly.io の設定ファイルを全体的に見直し

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -3,11 +3,20 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = "ai-cat-api"
-primary_region = "nrt"
+app = 'ai-cat-api'
+primary_region = 'nrt'
+
+[build]
 
 [http_service]
   internal_port = 5000
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
+  min_machines_running = 2
+  processes = ['app']
+
+[[vm]]
+  memory = '512mb'
+  cpu_kind = 'shared'
+  cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -19,4 +19,4 @@ primary_region = 'nrt'
 [[vm]]
   memory = '512mb'
   cpu_kind = 'shared'
-  cpus = 1
+  cpus = 2

--- a/stg-fly.toml
+++ b/stg-fly.toml
@@ -1,5 +1,7 @@
-app = "stg-ai-cat-api"
-primary_region = "nrt"
+app = 'stg-ai-cat-api'
+primary_region = 'nrt'
+
+[build]
 
 [http_service]
   internal_port = 5000
@@ -7,3 +9,9 @@ primary_region = "nrt"
   auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '512mb'
+  cpu_kind = 'shared'
+  cpus = 1


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/48

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/48 の完了の定義に記載されている通り、本番は最低2台のマシンが起動するように設定変更を実施する。

# 変更点概要

本番は最低2台のマシンが起動するように設定。

また最新テンプレートに従いFly.io の設定ファイルを全体的に見直し。

特に以前の書き方だと以下の部分が存在せずにマシンのスペックを確認がやりにくかったので追加したほうが良いと判断した。

```
[[vm]]
  memory = '512mb'
  cpu_kind = 'shared'
  cpus = 1
```

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし