### PR TITLE
評価用LLMと被評価LLMの temperature の調整

### DIFF
--- a/src/infrastructure/repository/openai/openai_cat_message_repository.py
+++ b/src/infrastructure/repository/openai/openai_cat_message_repository.py
@@ -53,7 +53,7 @@ class OpenAiCatMessageRepository(CatMessageRepositoryInterface):
             model="gpt-3.5-turbo-1106",
             messages=regenerated_messages,
             stream=True,
-            temperature=0.7,
+            temperature=0.1,
             user=user,
         )
 
@@ -120,7 +120,7 @@ class OpenAiCatMessageRepository(CatMessageRepositoryInterface):
         response = await self.client.chat.completions.create(
             model="gpt-3.5-turbo-1106",
             messages=copied_messages,
-            temperature=0.7,
+            temperature=0,
             user=str(dto.get("user_id")),
             tools=tools_params,
             tool_choice="auto",

--- a/tests/infrastructure/repository/openai/openai_cat_message_repository/test_generate_message_for_guest_user.py
+++ b/tests/infrastructure/repository/openai/openai_cat_message_repository/test_generate_message_for_guest_user.py
@@ -163,7 +163,7 @@ async def test_generate_message_for_guest_user(
     evaluation_response = await async_open_ai.chat.completions.create(
         model="gpt-4-turbo",
         messages=[{"role": "system", "content": evaluation_prompt}],
-        temperature=0.1,
+        temperature=0,
         user=dto.get("user_id"),
         response_format={"type": "json_object"},
     )


### PR DESCRIPTION
# issueURL

なし

# この PR で対応する範囲 / この PR で対応しない範囲

temperatureの調整を実施する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

回答にブレが出ないように temperature を調整。

基本的には全体的に小さい値に設定している。

Toolsの利用を判定する際は temperature を0に設定。

実際にねこの会話を生成する箇所は多少のランダム性があったほうが面白いので 0.1 に設定。

評価用LLMのtemperatureはできるだけ小さい値が望ましいので0に設定。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし