### PR TITLE
利用する言語モデルを gpt-4o に変更

### DIFF
--- a/src/domain/repository/cat_message_repository_interface.py
+++ b/src/domain/repository/cat_message_repository_interface.py
@@ -1,9 +1,11 @@
 from typing import Protocol, List, TypedDict
 from collections.abc import AsyncIterator
 from domain.message import ChatMessage
+from domain.cat import CatId
 
 
 class GenerateMessageForGuestUserDto(TypedDict):
+    cat_id: CatId
     user_id: str
     chat_messages: List[ChatMessage]
 

--- a/src/infrastructure/repository/openai/openai_cat_message_repository.py
+++ b/src/infrastructure/repository/openai/openai_cat_message_repository.py
@@ -18,6 +18,7 @@ from domain.repository.cat_message_repository_interface import (
     GenerateMessageForGuestUserDto,
     GenerateMessageForGuestUserResult,
 )
+from domain.cat import get_prompt_by_cat_id
 
 
 class FetchCurrentWeatherResponse(TypedDict):
@@ -50,7 +51,7 @@ class OpenAiCatMessageRepository(CatMessageRepositoryInterface):
         )
 
         response = await self.client.chat.completions.create(
-            model="gpt-3.5-turbo-1106",
+            model="gpt-4o",
             messages=regenerated_messages,
             stream=True,
             temperature=0.1,
@@ -107,10 +108,12 @@ class OpenAiCatMessageRepository(CatMessageRepositoryInterface):
         copied_messages = messages.copy()
 
         system_prompt = """
-        あなたの役割は与えられた会話履歴からtoolsの利用が必要かどうか判断する事です。
-        JSONのキーはuse_toolsとしてください。
-        toolsの利用が必要な場合はtrue,不要な場合はfalseを返します。
-        """
+        {base_system_prompt}
+        # Output Indicator
+        以下のようなJSON形式でお願いします。
+        ## use_tools
+        toolsの利用が必要な場合はtrue,不要な場合はfalseを設定します。
+        """.format(base_system_prompt=get_prompt_by_cat_id(dto.get("cat_id")))
 
         copied_messages[0] = {
             "role": "system",
@@ -118,7 +121,7 @@ class OpenAiCatMessageRepository(CatMessageRepositoryInterface):
         }
 
         response = await self.client.chat.completions.create(
-            model="gpt-3.5-turbo-1106",
+            model="gpt-4o",
             messages=copied_messages,
             temperature=0,
             user=str(dto.get("user_id")),

--- a/src/infrastructure/repository/openai/openai_cat_message_repository.py
+++ b/src/infrastructure/repository/openai/openai_cat_message_repository.py
@@ -18,7 +18,7 @@ from domain.repository.cat_message_repository_interface import (
     GenerateMessageForGuestUserDto,
     GenerateMessageForGuestUserResult,
 )
-from domain.cat import get_prompt_by_cat_id
+from domain.cat import get_prompt_by_cat_id, CatId
 
 
 class FetchCurrentWeatherResponse(TypedDict):
@@ -113,7 +113,9 @@ class OpenAiCatMessageRepository(CatMessageRepositoryInterface):
         以下のようなJSON形式でお願いします。
         ## use_tools
         toolsの利用が必要な場合はtrue,不要な場合はfalseを設定します。
-        """.format(base_system_prompt=get_prompt_by_cat_id(dto.get("cat_id")))
+        """.format(
+            base_system_prompt=get_prompt_by_cat_id(cast(CatId, dto.get("cat_id")))
+        )
 
         copied_messages[0] = {
             "role": "system",

--- a/src/usecase/generate_cat_message_for_guest_user_use_case.py
+++ b/src/usecase/generate_cat_message_for_guest_user_use_case.py
@@ -127,6 +127,7 @@ class GenerateCatMessageForGuestUserUseCase:
             ai_response_message = ""
 
             create_message_for_guest_user_dto = GenerateMessageForGuestUserDto(
+                cat_id=self.dto["cat_id"],
                 user_id=self.dto["user_id"],
                 chat_messages=chat_messages,
             )

--- a/tests/infrastructure/repository/openai/openai_cat_message_repository/test_generate_message_for_guest_user.py
+++ b/tests/infrastructure/repository/openai/openai_cat_message_repository/test_generate_message_for_guest_user.py
@@ -131,6 +131,7 @@ async def test_generate_message_for_guest_user(
     repository = OpenAiCatMessageRepository()
 
     dto = GenerateMessageForGuestUserDto(
+        cat_id="moko",
         user_id="0e9633ca-1002-47d3-92d4-45a322e7eba1",
         chat_messages=[
             {"role": "system", "content": get_prompt_by_cat_id("moko")},
@@ -161,7 +162,7 @@ async def test_generate_message_for_guest_user(
     async_open_ai = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
 
     evaluation_response = await async_open_ai.chat.completions.create(
-        model="gpt-4-turbo",
+        model="gpt-4o",
         messages=[{"role": "system", "content": evaluation_prompt}],
         temperature=0,
         user=dto.get("user_id"),


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/120

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/120 に記載されている通り、利用されている言語モデルを `gpt-4o` に変更する。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし

# 変更点概要

タイトルの通り利用する言語モデルを gpt-4o に変更。

モデルが高性能になった事で `tools` の利用判定を行っていたLLMの処理が常にfalseを返すようになってしまったので、ねこの人格を設定したプロンプトも一緒に渡す事でより正確に判定出来るようになっています。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし