### PR TITLE
Linter、Formatterを ruff に変更したので flake8 の設定ファイルを削除

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-exclude = .venv
-max-line-length = 120
-extend-ignore = E203

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     depends_on:
       - ai-cat-api-mysql
     volumes:
-      - ./.flake8:/.flake8
       - ./Makefile:/Makefile
       - ./pyproject.toml:/pyproject.toml
       - ./requirements.lock:/requirements.lock


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/125

# この PR で対応する範囲 / この PR で対応しない範囲

https://github.com/nekochans/ai-cat-api/issues/125 の完了の定義を満たす為に必要な内容は全てこのPRで実施します。

# 変更点概要

タイトルの通り、Linter、Formatterを ruff に変更したので flake8 の設定ファイルを削除。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし