### PR TITLE
API Docが見やすくなるように改善を実施

### DIFF
--- a/src/presentation/error_response_body.py
+++ b/src/presentation/error_response_body.py
@@ -1,23 +1,80 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Literal
 
 
 class UnauthorizedError(BaseModel):
-    type: Literal["UNAUTHORIZED"]
-    title: Literal["Invalid Authorization Header."]
+    type: Literal["UNAUTHORIZED"] = Field(
+        description="問題のタイプを識別する文字列 RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": ["UNAUTHORIZED"],
+        },
+    )
+    title: Literal["Invalid Authorization Header."] = Field(
+        description="エラーのタイトル RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": ["Invalid Authorization Header."],
+        },
+    )
 
 
 class UnexpectedErrorBody(BaseModel):
-    type: Literal["INTERNAL_SERVER_ERROR"]
-    title: Literal["an unexpected error has occurred."]
+    type: Literal["INTERNAL_SERVER_ERROR"] = Field(
+        description="問題のタイプを識別する文字列 RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": ["INTERNAL_SERVER_ERROR"],
+        },
+    )
+    title: Literal["an unexpected error has occurred."] = Field(
+        description="エラーのタイトル RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": ["an unexpected error has occurred."],
+        },
+    )
 
 
 class InvalidParam(BaseModel):
-    name: str
-    reason: str
+    name: str = Field(
+        description="バリデーションに引っかかったキー名 RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": ["userId", "message"],
+        },
+    )
+    reason: str = Field(
+        description="バリデーションに引っかかった理由 RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": [
+                "userId is not in UUID format",
+                "message must be at least 2 character and no more than 5,000 characters",
+            ],
+        },
+    )
 
 
 class ValidationErrorBody(BaseModel):
-    type: Literal["UNPROCESSABLE_ENTITY"]
-    title: Literal["validation Error."]
-    invalidParams: list[InvalidParam]
+    type: Literal["UNPROCESSABLE_ENTITY"] = Field(
+        description="問題のタイプを識別する文字列 RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": ["UNPROCESSABLE_ENTITY"],
+        },
+    )
+    title: Literal["validation Error."] = Field(
+        description="エラーのタイトル RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": ["validation Error."],
+        },
+    )
+    invalidParams: list[InvalidParam] = Field(
+        description="バリデーションエラーの詳細情報 RFC7807を参考に定義した https://zenn.dev/ryamakuchi/articles/d7c932afc57e30",
+        json_schema_extra={
+            "examples": [
+                {
+                    "name": "userId",
+                    "reason": "userId is not in UUID format",
+                },
+                {
+                    "name": "message",
+                    "reason": "message must be at least 2 character and no more than 5,000 characters",
+                },
+            ],
+        },
+    )

--- a/src/presentation/router/cats.py
+++ b/src/presentation/router/cats.py
@@ -47,10 +47,9 @@ async def generate_cat_message_for_guest_user(
     credentials: HTTPBasicCredentials = Depends(basic_auth),
 ) -> StreamingResponse:
     """
-    このエンドポイントはねこ型AIアシスタントのメッセージを生成します。
-    ゲストユーザー向けの機能です。よって画像や音声データの送信は不可となっています。
-
-    OpenAPIでは表現方法が分からないのでJSON形式になっていますが、実際にはServer Sent Events(SSE)形式のレスポンスが返却されます。
+    このエンドポイントはねこ型AIアシスタントのメッセージを生成します。 \n
+    ゲストユーザー向けの機能です。よって画像や音声データの送信は不可となっています。 \n
+    OpenAPIでは表現方法が分からないのでJSON形式になっていますが、実際には以下のようにServer Sent Events(SSE)形式のレスポンスが返却されます。 \n
 
     < HTTP/1.1 200 OK \n
     < date: Wed, 12 Jun 2024 15:49:51 GMT \n


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/128

# この PR で対応する範囲 / この PR で対応しない範囲

API Docのエラーレスポンスの説明を追記します。

APIエンドポイントの説明欄を改行して見やすくする。

# 変更点概要

以下の2つを実施。

- エラーレスポンスにOpenAPIのメタ情報を追加
- API Docを見やすく改行するように変更

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
