### PR TITLE
動画解析メソッドのレスポンスに文字起こし（transcript）を追加

### DIFF
--- a/src/domain/repository/video_repository_interface.py
+++ b/src/domain/repository/video_repository_interface.py
@@ -7,6 +7,7 @@ class AnalysisVideoDto(TypedDict):
 
 class AnalysisVideoResult(TypedDict):
     summary: str
+    transcript: str
 
 
 class VideoRepositoryInterface(Protocol):

--- a/src/infrastructure/repository/gemini/gemini_video_repository.py
+++ b/src/infrastructure/repository/gemini/gemini_video_repository.py
@@ -52,12 +52,14 @@ class GeminiVideoRepository(VideoRepositoryInterface):
             video,
             """
             # Instruction
-            動画の内容を確認して要約の作成をお願いします。
+            - 動画の内容を確認して要約の作成をお願いします。
+            - 動画の内容を文字起こし作成をお願いします。
             
             # 制約条件
             - 以下のJSON形式で返すようにお願いします。
-              - {"summary": "動画の要約文章をここに設定"}
+              - {"summary": "動画の要約文章をここに設定", "transcript": "動画の文字起こしをここに設定"}
                 - "summary" には動画の要約文章を設定します。
+                - "transcript" には動画の文字起こしを設定します。
             - ハルシネーションを起こさないでください。
             """,
         ]

--- a/src/infrastructure/repository/gemini/gemini_video_repository.py
+++ b/src/infrastructure/repository/gemini/gemini_video_repository.py
@@ -60,12 +60,16 @@ class GeminiVideoRepository(VideoRepositoryInterface):
               - {"summary": "動画の要約文章をここに設定", "transcript": "動画の文字起こしをここに設定"}
                 - "summary" には動画の要約文章を設定します。
                 - "transcript" には動画の文字起こしを設定します。
+                  - 文字起こしは長くなる事が多いので制限に引っかかりそうなら適切に要約してください。
             - ハルシネーションを起こさないでください。
             """,
         ]
 
         generation_config = {
             "response_mime_type": "application/json",
+            "temperature": 0.0,
+            "top_k": 1,
+            "top_p": 0.9,
         }
 
         response = await model.generate_content_async(
@@ -75,6 +79,9 @@ class GeminiVideoRepository(VideoRepositoryInterface):
 
         response_content = response.text
 
-        result: AnalysisVideoResult = json.loads(response_content)
+        try:
+            result: AnalysisVideoResult = json.loads(response_content)
+        except json.JSONDecodeError:
+            raise Exception(f"JSON decode error: {response_content}")
 
         return result

--- a/tests/infrastructure/repository/gemini/gemini_video_repository/test_analysis_video.py
+++ b/tests/infrastructure/repository/gemini/gemini_video_repository/test_analysis_video.py
@@ -22,10 +22,6 @@ def setup(worker_id: str) -> None:
             "gs://test-ai-cat/video-files/Cat.MOV",
             {"summary": "This is a summary of the video.", "transcript": "文字起こし"},
         ),
-        (
-            "gs://test-ai-cat/video-files/IMG_0401.MOV",
-            {"summary": "This is a summary of the video.", "transcript": "文字起こし"},
-        ),
     ],
 )
 async def test_analysis_video(video_url: str, expected_message: str) -> None:

--- a/tests/infrastructure/repository/gemini/gemini_video_repository/test_analysis_video.py
+++ b/tests/infrastructure/repository/gemini/gemini_video_repository/test_analysis_video.py
@@ -20,11 +20,11 @@ def setup(worker_id: str) -> None:
     [
         (
             "gs://test-ai-cat/video-files/Cat.MOV",
-            {"summary": "This is a summary of the video."},
+            {"summary": "This is a summary of the video.", "transcript": "文字起こし"},
         ),
         (
             "gs://test-ai-cat/video-files/IMG_0401.MOV",
-            {"summary": "This is a summary of the video."},
+            {"summary": "This is a summary of the video.", "transcript": "文字起こし"},
         ),
     ],
 )
@@ -40,5 +40,9 @@ async def test_analysis_video(video_url: str, expected_message: str) -> None:
     assert "summary" in result, "Result does not contain 'summary' key"
     assert isinstance(result["summary"], str), "'summary' is not a string"
     assert len(result["summary"]) > 0, "'summary' is an empty string"
+
+    assert "transcript" in result, "Result does not contain 'transcript' key"
+    assert isinstance(result["transcript"], str), "'transcript' is not a string"
+    assert len(result["transcript"]) > 0, "'transcript' is an empty string"
 
     # TODO: 後で評価用のLLMを使って expected_message と result["summary"] の類似度を評価する


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/136

# この PR で対応する範囲 / この PR で対応しない範囲

動画解析メソッドのレスポンスに文字起こし（transcript）を追加します。

# 変更点概要

This pull request introduces a new feature to include video transcripts in addition to summaries in the video analysis functionality. The changes span across the domain, infrastructure, and test files to support this new feature.

### Enhancements to Video Analysis:

* [`src/domain/repository/video_repository_interface.py`](diffhunk://#diff-fef89f77365077b86a05d959b56683a4732f42b8414d44c4076e9a3b5609262aR10): Added `transcript` field to the `AnalysisVideoResult` TypedDict.
* [`src/infrastructure/repository/gemini/gemini_video_repository.py`](diffhunk://#diff-eae9813c69a6faeb1907729111c4601691f52452802a4f538cdb0dd1ab2b001cL55-R72): Updated the `video_analysis` method to request and handle video transcripts along with summaries. Added error handling for JSON decode errors and updated the generation configuration. [[1]](diffhunk://#diff-eae9813c69a6faeb1907729111c4601691f52452802a4f538cdb0dd1ab2b001cL55-R72) [[2]](diffhunk://#diff-eae9813c69a6faeb1907729111c4601691f52452802a4f538cdb0dd1ab2b001cR82-R85)

### Test Updates:

* [`tests/infrastructure/repository/gemini/gemini_video_repository/test_analysis_video.py`](diffhunk://#diff-bb6ea63036676df0c1204ab975b809d91b2a16b9025af4dd9584b9de1e3d0d96L23-R23): Modified test setup data to include `transcript` and added assertions to validate the presence and correctness of the `transcript` field in the results. [[1]](diffhunk://#diff-bb6ea63036676df0c1204ab975b809d91b2a16b9025af4dd9584b9de1e3d0d96L23-R23) [[2]](diffhunk://#diff-bb6ea63036676df0c1204ab975b809d91b2a16b9025af4dd9584b9de1e3d0d96R40-R43)

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

動画の容量が大きいと文字起こしの出力が途中で止まってしまうので何か別の方法で解析する必要がありそう。
