### PR TITLE
VideoRepositoryのアプトプットに動画の長さ（秒単位）を追加

### DIFF
--- a/src/domain/repository/video_repository_interface.py
+++ b/src/domain/repository/video_repository_interface.py
@@ -7,7 +7,7 @@ class AnalysisVideoDto(TypedDict):
 
 class AnalysisVideoResult(TypedDict):
     summary: str
-    duration_in_seconds: float
+    duration_in_seconds: int
 
 
 class VideoRepositoryInterface(Protocol):

--- a/src/domain/repository/video_repository_interface.py
+++ b/src/domain/repository/video_repository_interface.py
@@ -7,6 +7,7 @@ class AnalysisVideoDto(TypedDict):
 
 class AnalysisVideoResult(TypedDict):
     summary: str
+    duration_in_seconds: float
 
 
 class VideoRepositoryInterface(Protocol):

--- a/src/infrastructure/repository/gemini/gemini_video_repository.py
+++ b/src/infrastructure/repository/gemini/gemini_video_repository.py
@@ -1,6 +1,9 @@
 import os
 import json
 import base64
+import ffmpeg
+import tempfile
+import math
 
 # TODO: なぜかmypyの型エラーになるので type: ignore で回避している
 from google.cloud import storage  # type: ignore
@@ -12,7 +15,8 @@ from domain.repository.video_repository_interface import (
     AnalysisVideoDto,
     AnalysisVideoResult,
 )
-from log.logger import AppLogger
+from log.logger import AppLogger, InfoLogExtra
+from infrastructure.google.parse_gcs_path import parse_gcs_path
 
 
 class GeminiVideoRepository(VideoRepositoryInterface):
@@ -43,6 +47,53 @@ class GeminiVideoRepository(VideoRepositoryInterface):
             location=os.getenv("GOOGLE_CLOUD_REGION"),
             credentials=self.credentials,
         )
+
+    def extract_video_duration(self, video_uri: str) -> float:
+        gcs_path_components = parse_gcs_path(video_uri)
+        bucket = self.google_cloud_storage_client.bucket(
+            gcs_path_components["bucket_name"]
+        )
+
+        file_path = video_uri.replace(f"gs://{gcs_path_components['bucket_name']}/", "")
+        blob = bucket.blob(file_path)
+
+        with tempfile.NamedTemporaryFile(
+            suffix=f".{gcs_path_components['file_extension']}"
+        ) as temp_file:
+            blob.download_to_filename(temp_file.name)
+            self.logger.info(
+                "GeminiVideoRepository.extract_video_duration.DownloadedVideo",
+                extra=InfoLogExtra(
+                    info_message=f"Downloaded {file_path} to {temp_file.name}",
+                ),
+            )
+            try:
+                probe = ffmpeg.probe(temp_file.name)
+                video_info = next(
+                    s for s in probe["streams"] if s["codec_type"] == "video"
+                )
+                duration = float(video_info["duration"])
+                self.logger.info(
+                    "GeminiVideoRepository.extract_video_duration.Success",
+                    extra=InfoLogExtra(
+                        info_message=f"Successfully extracted video duration: {duration} seconds"
+                    ),
+                )
+                return duration
+            except ffmpeg.Error as e:
+                self.logger.error(
+                    "GeminiVideoRepository.extract_video_duration.FFmpegError",
+                    extra=InfoLogExtra(info_message=f"FFmpeg error: {str(e)}"),
+                )
+                raise
+            except Exception as e:
+                self.logger.error(
+                    "GeminiVideoRepository.extract_video_duration.Error",
+                    extra=InfoLogExtra(
+                        info_message=f"Error retrieving video duration: {str(e)}"
+                    ),
+                )
+                raise
 
     async def video_analysis(self, dto: AnalysisVideoDto) -> AnalysisVideoResult:
         model = GenerativeModel(
@@ -85,7 +136,17 @@ class GeminiVideoRepository(VideoRepositoryInterface):
 
         try:
             result: AnalysisVideoResult = json.loads(response_content)
+            duration = self.extract_video_duration(dto["video_url"])
+            result["duration_in_seconds"] = math.floor(duration)
         except json.JSONDecodeError:
             raise Exception(f"JSON decode error: {response_content}")
+        except Exception as e:
+            self.logger.error(
+                "GeminiVideoRepository.video_analysis.Error",
+                extra=InfoLogExtra(
+                    info_message=f"Error during video analysis: {str(e)}"
+                ),
+            )
+            raise
 
         return result

--- a/tests/infrastructure/repository/gemini/gemini_video_repository/test_analysis_video.py
+++ b/tests/infrastructure/repository/gemini/gemini_video_repository/test_analysis_video.py
@@ -5,6 +5,7 @@ from src.infrastructure.repository.gemini.gemini_video_repository import (
 )
 from domain.repository.video_repository_interface import (
     AnalysisVideoDto,
+    AnalysisVideoResult,
 )
 
 
@@ -16,19 +17,19 @@ def setup(worker_id: str) -> None:
 @pytest.mark.skip(reason="APIの課金が発生する、実行時間が非常に長いため普段はスキップ")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "video_url, expected_message",
+    "video_url, expected",
     [
         (
             "gs://test-ai-cat/video-files/Cat.MOV",
-            {"summary": "This is a summary of the video."},
+            {"summary": "This is a summary of the video.", "duration_in_seconds": 42},
         ),
         (
             "gs://test-ai-cat/video-files/IMG_0401.MOV",
-            {"summary": "This is a summary of the video."},
+            {"summary": "This is a summary of the video.", "duration_in_seconds": 233},
         ),
     ],
 )
-async def test_analysis_video(video_url: str, expected_message: str) -> None:
+async def test_analysis_video(video_url: str, expected: AnalysisVideoResult) -> None:
     repository = GeminiVideoRepository()
 
     dto = AnalysisVideoDto(
@@ -40,5 +41,7 @@ async def test_analysis_video(video_url: str, expected_message: str) -> None:
     assert "summary" in result, "Result does not contain 'summary' key"
     assert isinstance(result["summary"], str), "'summary' is not a string"
     assert len(result["summary"]) > 0, "'summary' is an empty string"
+
+    assert result["duration_in_seconds"] == expected["duration_in_seconds"]
 
     # TODO: 後で評価用のLLMを使って expected_message と result["summary"] の類似度を評価する


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/142

# この PR で対応する範囲 / この PR で対応しない範囲

`VideoRepository.video_analysis` に動画の再生時間を追加する。

# 変更点概要

アプトプットに動画の長さ（秒単位）を表す `duration_in_seconds` を追加しました。

`VideoTranscriptRepository` にも同じ処理を追加したほうが良い気がしてきました。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし