### PR TITLE
コンテナ起動時に起きる以下のエラーを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG PYTHON_VERSION=3.12.4
-ARG PORT=5000
 
 FROM python:${PYTHON_VERSION}-slim AS build
 
@@ -25,10 +24,10 @@ RUN uv export -o requirements.txt --no-hashes
 
 RUN pip install --no-cache-dir --upgrade -r requirements.txt
 
-EXPOSE ${PORT}
+EXPOSE 5000
 
 ENV SSL_CERT_PATH /etc/ssl/certs/ca-certificates.crt
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "${PORT}"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5000"]


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/ai-cat-api/issues/156

# この PR で対応する範囲 / この PR で対応しない範囲

コンテナ起動時に起きる以下のエラーを修正します。

```
Error: Invalid value for '--port': '${PORT}' is not a valid integer.
```

# 変更点概要

以下のエラーが発生するのでポートを変数で定義するのをやめて数値型で定義する。

```
Error: Invalid value for '--port': '${PORT}' is not a valid integer.
```

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし